### PR TITLE
fix index new audiolist

### DIFF
--- a/lib/audio_manager.dart
+++ b/lib/audio_manager.dart
@@ -329,6 +329,8 @@ class AudioManager {
       }
       _curIndex = _randoms[_curIndex];
     }
+    if (_curIndex >= _audioList.length)
+      _curIndex = _audioList.length - 1;
     return _audioList[_curIndex];
   }
 


### PR DESCRIPTION

fixed when playing a track with an index greater than the length of the new list, this causes an error