### PR TITLE
Fix inconsistent behavior when in shuffle mode

### DIFF
--- a/lib/audio_manager.dart
+++ b/lib/audio_manager.dart
@@ -59,6 +59,7 @@ class AudioManager {
   /// list of playback. Used to record playlists
   List<AudioInfo> get audioList => _audioList;
   List<AudioInfo> _audioList = [];
+  final _random = Random();
 
   /// Set up playlists. Use the [play] or [start] method if you want to play
   set audioList(List<AudioInfo> list) {
@@ -356,9 +357,8 @@ class AudioManager {
     int newIndex = _curIndex;
 
     // Make sure that we don't re-select the current index
-    final random = Random();
     do {
-      newIndex = random.nextInt(_audioList.length);
+      newIndex = _random.nextInt(_audioList.length);
     } while (newIndex == _curIndex);
 
     return newIndex;

--- a/lib/audio_manager.dart
+++ b/lib/audio_manager.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:audio_manager/src/AudioType.dart';
 import 'package:audio_manager/src/AudioInfo.dart';
 
+import 'src/AudioType.dart';
+
 export 'package:audio_manager/src/AudioInfo.dart';
 export 'package:audio_manager/src/AudioType.dart';
 
@@ -71,6 +73,7 @@ class AudioManager {
   int get curIndex => _curIndex;
   int _curIndex = 0;
   List<int> _randoms = [];
+  List<int> _randomsReverse = [];
 
   /// Play mode [sequence, shuffle, single], default `sequence`
   PlayMode get playMode => _playMode;
@@ -349,6 +352,11 @@ class AudioManager {
       if (_randoms.length != _audioList.length) {
         _randoms = _audioList.asMap().keys.toList();
         _randoms.shuffle();
+
+        _randomsReverse = List<int>.filled(_randoms.length, 0);
+        for (int i = 0; i < _randoms.length; ++i) {
+          _randomsReverse[_randoms[i]] = i;
+        }
       }
       _curIndex = _randoms[_curIndex];
     }
@@ -371,9 +379,15 @@ class AudioManager {
 
   /// play previous audio
   Future<String> previous() async {
-    if (playMode != PlayMode.single) {
-      int index = _curIndex - 1;
-      _curIndex = index < 0 ? _audioList.length - 1 : index;
+    switch (playMode) {
+      case PlayMode.sequence:
+        int index = _curIndex - 1;
+        _curIndex = index < 0 ? _audioList.length - 1 : index;
+        break;
+      case PlayMode.shuffle:
+        _curIndex = _randomsReverse[_curIndex];
+        break;
+      default:
     }
     return await play();
   }


### PR DESCRIPTION
The shuffle mode has a few inconsistent behavior. For example, take the following shuffled indices:

```
[0]:1
[1]:11
[2]:5
[3]:6
[4]:9
[5]:2
[6]:10
[7]:8
[8]:3
[9]:0
[10]:4
[11]:7
```

If we are currently playing index `8`, calling `previous()` while in shuffle mode will decrement the index by 1 so it becomes `7`, and then we will re-select the index `8`. Instead of generating a shuffled array that can make loops possible or may make it impossible to go back or go forward, we can just generate random indices on the fly instead, while making sure that we don't generate the same index as the currently selected one.