### PR TITLE
ci: fix publish workflow for v0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,9 @@ on:
 jobs:
   verify-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Require tag on master
@@ -20,30 +21,20 @@ jobs:
             exit 1
           fi
 
-  publish:
+  test:
     needs: verify-tag
     runs-on: ubuntu-latest
-    environment: pub
-    permissions:
-      contents: read
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
       - run: flutter pub get
       - run: flutter test
-      - name: Verify pub.dev credentials
-        env:
-          PUB_DEV_PUBLISH_ACCESS_TOKEN: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
-          PUB_DEV_PUBLISH_REFRESH_TOKEN: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}
-        run: |
-          if [[ -z "$PUB_DEV_PUBLISH_ACCESS_TOKEN" || -z "$PUB_DEV_PUBLISH_REFRESH_TOKEN" ]]; then
-            echo "::error::Set PUB_DEV_PUBLISH_ACCESS_TOKEN and PUB_DEV_PUBLISH_REFRESH_TOKEN"
-            exit 1
-          fi
-      - name: Publish to pub.dev
-        env:
-          PUB_DEV_PUBLISH_ACCESS_TOKEN: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
-          PUB_DEV_PUBLISH_REFRESH_TOKEN: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}
-        run: flutter pub publish --force
+
+  publish:
+    needs: [verify-tag, test]
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
修复 v0.9.2 发布 workflow。

- 切换到 dart-lang/setup-dart 官方 OIDC 发布流程，移除不再生效的 PUB_DEV_PUBLISH_* OAuth 环境变量
- 保留 master tag 校验和发布前 flutter test
- 升级 actions/checkout 到 v6，消除 Node.js 20 弃用告警