### PR TITLE
ci: show pub.dev releases in GitHub deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,3 +38,5 @@ jobs:
     permissions:
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub


### PR DESCRIPTION
让后续 pub.dev 发布使用 environment: pub，在 GitHub Deployments 中显示发布记录。